### PR TITLE
add cleanup cache option

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -32,6 +32,12 @@ var upCmd = &cobra.Command{
 		}
 		logger.Info("force update = %t", isForceUpdate)
 
+		isCleanupCache, err := cmd.Flags().GetBool("cleanup")
+		if err != nil {
+			return err
+		}
+		logger.Info("cleanup cache = %t", isCleanupCache)
+
 		identityFile, err := cmd.Flags().GetString("identity-file")
 		if err != nil {
 			return err
@@ -58,7 +64,7 @@ var upCmd = &cobra.Command{
 
 		authProvider = helper.NewAuthProvider(filepath.Join(homeDir, ".ssh", identityFile), password)
 		updateService := service.NewSync(authProvider, homeDir, pwd, pwd)
-		return updateService.Resolve(isForceUpdate)
+		return updateService.Resolve(isForceUpdate, isCleanupCache)
 	},
 }
 
@@ -66,4 +72,5 @@ func initDepCmd() {
 	upCmd.PersistentFlags().BoolP("force", "f", false, "update locked file and .proto vendors")
 	upCmd.PersistentFlags().StringP("identity-file", "i", "id_rsa", "set the identity file for SSH")
 	upCmd.PersistentFlags().StringP("password", "p", "", "set the password for SSH")
+	upCmd.PersistentFlags().BoolP("cleanup", "c", false, "cleanup cache before exec.")
 }

--- a/service/sync_test.go
+++ b/service/sync_test.go
@@ -38,7 +38,7 @@ func TestSync(t *testing.T) {
 
 	target := NewSync(authProviderMock, dotProtoDir, pwd, outputRootDir)
 	// clone
-	err = target.Resolve(false)
+	err = target.Resolve(false, false)
 	require.NoError(t, err)
 
 	if !isFileExist(filepath.Join(outputRootDir, "proto/stream.proto")) {
@@ -49,7 +49,7 @@ func TestSync(t *testing.T) {
 	}
 
 	// fetch
-	err = target.Resolve(false)
+	err = target.Resolve(false, false)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
git repositoryキャッシュクリア対応。

Windows環境にて、git repositoryをPullした時点でattribute等の変更が発生してしまうrepositoryがあることから、２回目以降の実施時にも問題なく実施できるよう、gitレポジトリのキャッシュを削除するオプションを追加する。